### PR TITLE
Support Celery v5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ setup(name='thumbnailq',
       package_data={"thumbnailq": ['tasks/files/*.png', 'thumbnailq/tasks/files/*.png']},
       include_package_data=True,
       install_requires=[
-          'celery==4.4.7',
-          'pymongo==3.11.0',
-          'Wand'
+          'Wand',
+          'Pillow'
       ],
 )

--- a/thumbnailq/tasks/tasks.py
+++ b/thumbnailq/tasks/tasks.py
@@ -1,10 +1,14 @@
-from celery.task import task
+from celery import Celery
+import celeryconfig
 from wand.image import Image
 from wand.color import Color
 from boto3 import client
 from shutil import copyfile
 import hashlib, textwrap, boto3, os,pathlib,tempfile
 from PIL import Image as IG
+
+app = Celery()
+app.config_from_object(celeryconfig)
 
 def imageThumbnail(bucket,key,target_fname,width=100,height=100,force_exists=False):
     
@@ -93,7 +97,7 @@ def genS3Objct(bucket,key):
     s3_response_object = s3_client.get_object(Bucket=bucket, Key=key)
     return s3_response_object['Body']
 
-@task()
+@app.task()
 def generateObjectThumbnail(bucket,key,width=100,height=100,force_exists=False,target_base='/static_secure/thumbnails'):
     """
     Taskname: generateObjectThumbnail
@@ -116,7 +120,8 @@ def generateObjectThumbnail(bucket,key,width=100,height=100,force_exists=False,t
         pass
     return result
 
-@task()
+#@task()
+@app.task()
 def generateBucketThumbnail(bucket,width=100,height=100,force_exists=False,target_base='/static_secure/thumbnails'):
     """
     Taskname: generateBucketThumbnail


### PR DESCRIPTION
# PR Title
Support Celery v5 API changes

## Summary
This PR updates the **Thumbnail Celery Task** to work with the new Celery v5 API.

## Change Log
1. Remove installing base packages that are including in the base Cybercom container (ie: pymongo, celery)
2. Add installing packages not in the base container that are specific to this task (ie: Pillow).
3. Update to follow changes in v5 of Celery API specifically removal of the celery.task module and importing directly from the Celery module instead.  This follows the changes made to the [sample cybercom task](https://github.com/cybercommons/cybercomq/tree/celery5).

## Breaking Changes
- This version of the Thumbnailq task requires at least version v5.0 of Celery and has been tested with Celery v5.2.7.